### PR TITLE
remove new to plotly section from top of docs

### DIFF
--- a/ggplot2/2011-11-29-scale-x.Rmd
+++ b/ggplot2/2011-11-29-scale-x.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2011-11-29-scale-x.Rmd
+++ b/ggplot2/2011-11-29-scale-x.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ## By Month
 
 ```{r}

--- a/ggplot2/2011-11-29-scale-y.Rmd
+++ b/ggplot2/2011-11-29-scale-y.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2011-11-29-scale-y.Rmd
+++ b/ggplot2/2011-11-29-scale-y.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ## Basic
 
 ```{r}

--- a/ggplot2/2016-11-29-aes.Rmd
+++ b/ggplot2/2016-11-29-aes.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Fill
 
 ```{r}

--- a/ggplot2/2016-11-29-aes.Rmd
+++ b/ggplot2/2016-11-29-aes.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-axis-text.Rmd
+++ b/ggplot2/2016-11-29-axis-text.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Axis Text Size
 
 ```{r}

--- a/ggplot2/2016-11-29-axis-text.Rmd
+++ b/ggplot2/2016-11-29-axis-text.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-axis-ticks.Rmd
+++ b/ggplot2/2016-11-29-axis-ticks.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Axis Labels
 
 ```{r}

--- a/ggplot2/2016-11-29-axis-ticks.Rmd
+++ b/ggplot2/2016-11-29-axis-ticks.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-axis-title.Rmd
+++ b/ggplot2/2016-11-29-axis-title.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Axis Labels
 
 ```{r}

--- a/ggplot2/2016-11-29-axis-title.Rmd
+++ b/ggplot2/2016-11-29-axis-title.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-facet-grid.Rmd
+++ b/ggplot2/2016-11-29-facet-grid.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic
 
 ```{r}

--- a/ggplot2/2016-11-29-facet-grid.Rmd
+++ b/ggplot2/2016-11-29-facet-grid.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-facet-wrap.Rmd
+++ b/ggplot2/2016-11-29-facet-wrap.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Columns
 
 ```{r}

--- a/ggplot2/2016-11-29-facet-wrap.Rmd
+++ b/ggplot2/2016-11-29-facet-wrap.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_abline.Rmd
+++ b/ggplot2/2016-11-29-geom_abline.Rmd
@@ -18,12 +18,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_abline.Rmd
+++ b/ggplot2/2016-11-29-geom_abline.Rmd
@@ -17,19 +17,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Line
 add line for mean using <code>geom_vline</code>
 

--- a/ggplot2/2016-11-29-geom_bar.Rmd
+++ b/ggplot2/2016-11-29-geom_bar.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_bar.Rmd
+++ b/ggplot2/2016-11-29-geom_bar.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Bar Chart
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_boxplot.Rmd
+++ b/ggplot2/2016-11-29-geom_boxplot.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_boxplot.Rmd
+++ b/ggplot2/2016-11-29-geom_boxplot.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Boxplot
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_density.Rmd
+++ b/ggplot2/2016-11-29-geom_density.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_density.Rmd
+++ b/ggplot2/2016-11-29-geom_density.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Density Plot
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_errorbar.Rmd
+++ b/ggplot2/2016-11-29-geom_errorbar.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_errorbar.Rmd
+++ b/ggplot2/2016-11-29-geom_errorbar.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Error Bar
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_histogram.Rmd
+++ b/ggplot2/2016-11-29-geom_histogram.Rmd
@@ -18,12 +18,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_histogram.Rmd
+++ b/ggplot2/2016-11-29-geom_histogram.Rmd
@@ -17,19 +17,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Histogram
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_line.Rmd
+++ b/ggplot2/2016-11-29-geom_line.Rmd
@@ -18,12 +18,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_line.Rmd
+++ b/ggplot2/2016-11-29-geom_line.Rmd
@@ -17,19 +17,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Line Plot
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_point.Rmd
+++ b/ggplot2/2016-11-29-geom_point.Rmd
@@ -18,12 +18,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_point.Rmd
+++ b/ggplot2/2016-11-29-geom_point.Rmd
@@ -17,19 +17,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Scatter Chart
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_polygon.Rmd
+++ b/ggplot2/2016-11-29-geom_polygon.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_polygon.Rmd
+++ b/ggplot2/2016-11-29-geom_polygon.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Ploygon
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_ribbon.Rmd
+++ b/ggplot2/2016-11-29-geom_ribbon.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_ribbon.Rmd
+++ b/ggplot2/2016-11-29-geom_ribbon.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Line & Ribbon 
 
 ```{r}

--- a/ggplot2/2016-11-29-geom_smooth.Rmd
+++ b/ggplot2/2016-11-29-geom_smooth.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-geom_smooth.Rmd
+++ b/ggplot2/2016-11-29-geom_smooth.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Gaussian
 
 ```{r}

--- a/ggplot2/2016-11-29-hover.Rmd
+++ b/ggplot2/2016-11-29-hover.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2016-11-29-hover.Rmd
+++ b/ggplot2/2016-11-29-hover.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Maps
 
 ```{r}

--- a/ggplot2/2016-11-29-stat_smooth.Rmd
+++ b/ggplot2/2016-11-29-stat_smooth.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic
 
 ```{r}

--- a/ggplot2/2016-11-29-stat_smooth.Rmd
+++ b/ggplot2/2016-11-29-stat_smooth.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2017-04-21-geom_quantile.Rmd
+++ b/ggplot2/2017-04-21-geom_quantile.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Example
 While common linear regression is a method of estimating the conditional mean of variable y based on the values of variable(s) x, quantile regression is a method that can give the conditional median (50th percentile) as well as any other quantile.
 

--- a/ggplot2/2017-04-21-geom_quantile.Rmd
+++ b/ggplot2/2017-04-21-geom_quantile.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2017-04-21-geom_rug.Rmd
+++ b/ggplot2/2017-04-21-geom_rug.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2017-04-21-geom_rug.Rmd
+++ b/ggplot2/2017-04-21-geom_rug.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Example
 
 ```{r}

--- a/ggplot2/2017-04-21-geom_spoke.Rmd
+++ b/ggplot2/2017-04-21-geom_spoke.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2017-04-21-geom_spoke.Rmd
+++ b/ggplot2/2017-04-21-geom_spoke.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Example
 
 ```{r}

--- a/ggplot2/2017-06-10-ggplot2-cumulative-animations.Rmd
+++ b/ggplot2/2017-06-10-ggplot2-cumulative-animations.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2017-06-10-ggplot2-cumulative-animations.Rmd
+++ b/ggplot2/2017-06-10-ggplot2-cumulative-animations.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Frames
 
 Now, along with `data` and `layout`, `frames` is added to the keys that `figure` allows. Your `frames` key points to a list of figures, each of which will be cycled through upon instantiation of the plot.

--- a/ggplot2/2017-06-10-ggplot2-intro-to-animations.Rmd
+++ b/ggplot2/2017-06-10-ggplot2-intro-to-animations.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2017-06-10-ggplot2-intro-to-animations.Rmd
+++ b/ggplot2/2017-06-10-ggplot2-intro-to-animations.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Frames
 
 Now, along with `data` and `layout`, `frames` is added to the keys that `figure` allows. Your `frames` key points to a list of figures, each of which will be cycled through upon instantiation of the plot.

--- a/ggplot2/2017-10-18-extending_ggplotly.Rmd
+++ b/ggplot2/2017-10-18-extending_ggplotly.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2017-10-18-extending_ggplotly.Rmd
+++ b/ggplot2/2017-10-18-extending_ggplotly.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Modify with Style
 
 ```{r}

--- a/ggplot2/2018-06-22-geom_sf.Rmd
+++ b/ggplot2/2018-06-22-geom_sf.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2018-06-22-geom_sf.Rmd
+++ b/ggplot2/2018-06-22-geom_sf.Rmd
@@ -25,7 +25,7 @@ The examples below use the library [simple features](https://r-spatial.github.io
 
 ### Basic sf 
 
-``` {r}
+```{r}
 library(plotly)
 library(sf)
 

--- a/ggplot2/2018-06-22-geom_sf.Rmd
+++ b/ggplot2/2018-06-22-geom_sf.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Introduction
 
 In order to complete the examples below, you'll require installing additional packages (`install.packages("packageName")`):

--- a/ggplot2/2019-07-12-geom_bin2d.Rmd
+++ b/ggplot2/2019-07-12-geom_bin2d.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-07-12-geom_bin2d.Rmd
+++ b/ggplot2/2019-07-12-geom_bin2d.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic 2d Heatmap
 See also geom\_hex for a similar geom with hexagonal bins. Note: facetting is supported in geom\_bin2d but not geom\_hex.
 

--- a/ggplot2/2019-07-30-geom_hex.Rmd
+++ b/ggplot2/2019-07-30-geom_hex.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-07-30-geom_hex.Rmd
+++ b/ggplot2/2019-07-30-geom_hex.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic 2d Heatmap
 See also [geom_bin2d](https://plot.ly/ggplot2/geom_bin2d/) for a similar geom with rectangular bins. Note: facetting is supported in geom\_bin2d but not geom\_hex.
 

--- a/ggplot2/2019-07-30-geom_text.Rmd
+++ b/ggplot2/2019-07-30-geom_text.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-07-30-geom_text.Rmd
+++ b/ggplot2/2019-07-30-geom_text.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Text Graph
 Sources: [International IDEA](https://www.idea.int/data-tools/continent-view/Europe/40?st=par#rep) for national turnout and [European Parliament](https://election-results.eu/turnout/) for European turnout, while regional classifications are based on [EuroVoc](https://publications.europa.eu/en/web/eu-vocabularies/th-concept-scheme/-/resource/eurovoc/100277?target=Browse).
 

--- a/ggplot2/2019-08-02-geom_violin.Rmd
+++ b/ggplot2/2019-08-02-geom_violin.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-02-geom_violin.Rmd
+++ b/ggplot2/2019-08-02-geom_violin.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic violin plot
 A basic violin plot showing how Democratic vote share in the 2018 elections to the US House of Representatives varied by level of density. A horizontal bar is added, to divide candidates who lost from those who won.
 

--- a/ggplot2/2019-08-06-geom_density2d.Rmd
+++ b/ggplot2/2019-08-06-geom_density2d.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic 2D Graph
 Source: [Brett Carpenter from Data.World](https://data.world/brettcarpenter/craft-beer-data)
 

--- a/ggplot2/2019-08-06-geom_density2d.Rmd
+++ b/ggplot2/2019-08-06-geom_density2d.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-06-geom_jitter.Rmd
+++ b/ggplot2/2019-08-06-geom_jitter.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-06-geom_jitter.Rmd
+++ b/ggplot2/2019-08-06-geom_jitter.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Jitter Plot
 You can use the "text=" option to control what pops when you hover over each point. (Note: you might get an error message when running this function; ggplot does not recognize it but the plotly function does.)
 

--- a/ggplot2/2019-08-08-geom_count.Rmd
+++ b/ggplot2/2019-08-08-geom_count.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-08-geom_count.Rmd
+++ b/ggplot2/2019-08-08-geom_count.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic geom\_count Plot
 geom\_count is a way to plot two variables that are not continuous. Here's a modified version of the nycflights13 dataset that comes with R; it shows 2013 domestic flights leaving New York's three airports. This graph maps two categorical variables: which of America's major airports it was headed to, and which major carrier was operating it.
 

--- a/ggplot2/2019-08-09-geom_contour.Rmd
+++ b/ggplot2/2019-08-09-geom_contour.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-09-geom_contour.Rmd
+++ b/ggplot2/2019-08-09-geom_contour.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic geom\_contour plot
 geom\_contour produces a similar output to geom\_density\_2d, except it uses a third variable for the values rather than frequency. The volcano dataset comes pre-loaded on R.
 

--- a/ggplot2/2019-08-09-geom_rect.Rmd
+++ b/ggplot2/2019-08-09-geom_rect.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-09-geom_rect.Rmd
+++ b/ggplot2/2019-08-09-geom_rect.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### geom\_rect with a line graph
 geom\_rect is defined by its four sides (xmin, xmax, ymin, ymax), which are all included in the dataset. Fill refers to the colour of the rectangle, colour refers to the border, and size refers to the border width.
 

--- a/ggplot2/2019-08-12-geom_raster.Rmd
+++ b/ggplot2/2019-08-12-geom_raster.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-12-geom_raster.Rmd
+++ b/ggplot2/2019-08-12-geom_raster.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic 2d Heatmap
 geom\_raster creates a coloured heatmap, with two variables acting as the x- and y-coordinates and a third variable mapping onto a colour. (It is coded similarly to geom\_tile and is generated more quickly.) This uses the volcano dataset that comes pre-loaded with R.
 

--- a/ggplot2/2019-08-12-geom_tile.Rmd
+++ b/ggplot2/2019-08-12-geom_tile.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-12-geom_tile.Rmd
+++ b/ggplot2/2019-08-12-geom_tile.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic geom\_tile graph
 This graph, compiled by [Jeff Zimmerman](https://docs.google.com/spreadsheets/d/1HI-dikWN64clxSGJu2QV8C64R9Bkzt8K-jFaeHj4X7k/edit#gid=0), shows how often hitters swing and miss at fastballs, based on their velocity and spin rate. Colour schemes are from ColorBrewer; a complete list of palettes is available [here](https://ggplot2.tidyverse.org/reference/scale_brewer.html).
 

--- a/ggplot2/2019-08-27-geom_qq.Rmd
+++ b/ggplot2/2019-08-27-geom_qq.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/ggplot2/2019-08-27-geom_qq.Rmd
+++ b/ggplot2/2019-08-27-geom_qq.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic geom\_qq graph
 A quantile-quantile graph is used to determine whether a range of numbers follows a certain distribution: the closer the data points are to being a straight line, the closer the data is to the distribution. (The default distribution is normal.) This dataset gives the daily change in the S&P 500, as well as Apple, Microsoft, IBM, and Starbucks stocks between January 2007 and February 2016.
 

--- a/r/2015-07-30-2D-Histogram.Rmd
+++ b/r/2015-07-30-2D-Histogram.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic 2D Histogram
 
 2D histograms require `x`/`y`, but in contrast to heatmaps, `z` is optional. If `z` is not provided, binning occurs in the browser (see [here](https://plot.ly/r/reference/#histogram2d-histnorm) for a list of binning options).

--- a/r/2015-07-30-2D-Histogram.Rmd
+++ b/r/2015-07-30-2D-Histogram.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-3d-line-plots.Rmd
+++ b/r/2015-07-30-3d-line-plots.Rmd
@@ -16,18 +16,6 @@ thumbnail: thumbnail/3d-line.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic 3D Line Plot
 
 ```{r}

--- a/r/2015-07-30-3d-line-plots.Rmd
+++ b/r/2015-07-30-3d-line-plots.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/3d-line.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-3d-scatter-plots.Rmd
+++ b/r/2015-07-30-3d-scatter-plots.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/3d-scatter.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-3d-scatter-plots.Rmd
+++ b/r/2015-07-30-3d-scatter-plots.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/3d-scatter.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic 3D Scatter Plot
 
 ```{r}

--- a/r/2015-07-30-3d-surface-plots.Rmd
+++ b/r/2015-07-30-3d-surface-plots.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/3d-surface.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-3d-surface-plots.Rmd
+++ b/r/2015-07-30-3d-surface-plots.Rmd
@@ -16,18 +16,6 @@ thumbnail: thumbnail/3d-surface.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 # Basic 3D Surface Plot
 
 ```{r}

--- a/r/2015-07-30-LaTeX.Rmd
+++ b/r/2015-07-30-LaTeX.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/creating-and-updating-figures.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### LaTeX Typesetting
 
 

--- a/r/2015-07-30-LaTeX.Rmd
+++ b/r/2015-07-30-LaTeX.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/creating-and-updating-figures.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-axes.Rmd
+++ b/r/2015-07-30-axes.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/axes.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r, results = "hide"}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Style Axes Ticks and Placement
 
 ```{r}

--- a/r/2015-07-30-axes.Rmd
+++ b/r/2015-07-30-axes.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/axes.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-bar-charts.Rmd
+++ b/r/2015-07-30-bar-charts.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Bar Chart
 
 ```{r}

--- a/r/2015-07-30-bar-charts.Rmd
+++ b/r/2015-07-30-bar-charts.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-box-plots.Rmd
+++ b/r/2015-07-30-box-plots.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Boxplot
 
 ```{r}

--- a/r/2015-07-30-box-plots.Rmd
+++ b/r/2015-07-30-box-plots.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-bubble-charts.Rmd
+++ b/r/2015-07-30-bubble-charts.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Simple Bubble Chart
 
 ```{r}

--- a/r/2015-07-30-bubble-charts.Rmd
+++ b/r/2015-07-30-bubble-charts.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-bubble-maps.Rmd
+++ b/r/2015-07-30-bubble-maps.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/bubble-map.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### United States Bubble Map
 
 ```{r}

--- a/r/2015-07-30-bubble-maps.Rmd
+++ b/r/2015-07-30-bubble-maps.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/bubble-map.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-choropleth.Rmd
+++ b/r/2015-07-30-choropleth.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/choropleth.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 # Choropleth Maps in R
 ```{r}
 library(plotly)

--- a/r/2015-07-30-choropleth.Rmd
+++ b/r/2015-07-30-choropleth.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/choropleth.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-contour-plots.Rmd
+++ b/r/2015-07-30-contour-plots.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/contour.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-contour-plots.Rmd
+++ b/r/2015-07-30-contour-plots.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/contour.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Contour
 
 ```{r}

--- a/r/2015-07-30-dumbbell-plots.Rmd
+++ b/r/2015-07-30-dumbbell-plots.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 # Dot and Dumbbell Plots
 
 ```{r}

--- a/r/2015-07-30-dumbbell-plots.Rmd
+++ b/r/2015-07-30-dumbbell-plots.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-figure-labels.Rmd
+++ b/r/2015-07-30-figure-labels.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/figure-labels.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Figure Labels for 2D Charts
 ```{r}
 library(plotly)

--- a/r/2015-07-30-figure-labels.Rmd
+++ b/r/2015-07-30-figure-labels.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/figure-labels.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-filled-area-plots.Rmd
+++ b/r/2015-07-30-filled-area-plots.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Filled Area Plot
 
 To make an area plot with interior filling set `fill` to `"tozeroy"` in the call for the second trace.

--- a/r/2015-07-30-filled-area-plots.Rmd
+++ b/r/2015-07-30-filled-area-plots.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-graphing-multiple-chart-types.Rmd
+++ b/r/2015-07-30-graphing-multiple-chart-types.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Bar and Line Chart
 
 ```{r}

--- a/r/2015-07-30-graphing-multiple-chart-types.Rmd
+++ b/r/2015-07-30-graphing-multiple-chart-types.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-heatmaps.Rmd
+++ b/r/2015-07-30-heatmaps.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/heatmap.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic Heatmap
 
 ```{r}

--- a/r/2015-07-30-heatmaps.Rmd
+++ b/r/2015-07-30-heatmaps.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/heatmap.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-histograms.Rmd
+++ b/r/2015-07-30-histograms.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic Histogram
 
 ```{r}

--- a/r/2015-07-30-histograms.Rmd
+++ b/r/2015-07-30-histograms.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-insets.Rmd
+++ b/r/2015-07-30-insets.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic Inset
 
 See also the [chapter on subplots in the plotly book](https://cpsievert.github.io/plotly_book/subplot.html)

--- a/r/2015-07-30-insets.Rmd
+++ b/r/2015-07-30-insets.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-legend.Rmd
+++ b/r/2015-07-30-legend.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/legends.gif
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-legend.Rmd
+++ b/r/2015-07-30-legend.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/legends.gif
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Legend Names
 
 ```{r}

--- a/r/2015-07-30-line-and-scatter.Rmd
+++ b/r/2015-07-30-line-and-scatter.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-line-and-scatter.Rmd
+++ b/r/2015-07-30-line-and-scatter.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Scatter Plot
 
 ```{r}

--- a/r/2015-07-30-line-plot-maps.Rmd
+++ b/r/2015-07-30-line-plot-maps.Rmd
@@ -18,17 +18,6 @@ thumbnail: thumbnail/flight-paths.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Flight Paths Map
 
 ```{r}

--- a/r/2015-07-30-line-plot-maps.Rmd
+++ b/r/2015-07-30-line-plot-maps.Rmd
@@ -18,12 +18,7 @@ thumbnail: thumbnail/flight-paths.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-log-plot.Rmd
+++ b/r/2015-07-30-log-plot.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/log.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-log-plot.Rmd
+++ b/r/2015-07-30-log-plot.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/log.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Log Axes
 
 ```{r}

--- a/r/2015-07-30-map-subplots-and-small-multiples.Rmd
+++ b/r/2015-07-30-map-subplots-and-small-multiples.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Subplots with Maps
 
 ```{r}

--- a/r/2015-07-30-map-subplots-and-small-multiples.Rmd
+++ b/r/2015-07-30-map-subplots-and-small-multiples.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-multiple-axes.Rmd
+++ b/r/2015-07-30-multiple-axes.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Multiple Y Axes
 
 ```{r}

--- a/r/2015-07-30-multiple-axes.Rmd
+++ b/r/2015-07-30-multiple-axes.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-polar-chart.Rmd
+++ b/r/2015-07-30-polar-chart.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-polar-chart.Rmd
+++ b/r/2015-07-30-polar-chart.Rmd
@@ -17,18 +17,6 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
-
 ### Legacy Plots
 
 These polar charts are legacy and will likely be deprecated in [Plotly 2.0](https://github.com/plotly/plotly.js/issues/420). Please see the new `scatterpolar` and `scatterpolargl` [trace types](https://plot.ly/r/polar-chart/) for latest and greatest in Plotly polar coordinates.

--- a/r/2015-07-30-range-slider-selector.Rmd
+++ b/r/2015-07-30-range-slider-selector.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Range Slider and Selector Buttons
 
 ```{r}

--- a/r/2015-07-30-range-slider-selector.Rmd
+++ b/r/2015-07-30-range-slider-selector.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-scatter-plot-maps.Rmd
+++ b/r/2015-07-30-scatter-plot-maps.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/scatter-plot-on-maps.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-scatter-plot-maps.Rmd
+++ b/r/2015-07-30-scatter-plot-maps.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/scatter-plot-on-maps.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Scatter on Map
 
 ```{r}

--- a/r/2015-07-30-setting-graph-size.Rmd
+++ b/r/2015-07-30-setting-graph-size.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/sizing.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-setting-graph-size.Rmd
+++ b/r/2015-07-30-setting-graph-size.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/sizing.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Customize Margins and Plot Size
 ```{r}
 library(plotly)

--- a/r/2015-07-30-subplots.Rmd
+++ b/r/2015-07-30-subplots.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-subplots.Rmd
+++ b/r/2015-07-30-subplots.Rmd
@@ -16,16 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
 ### Basic Subplots
 
 The subplot() function provides a flexible interface for merging plotly objects into a single object (i.e., view).

--- a/r/2015-07-30-text-and-annotations.Rmd
+++ b/r/2015-07-30-text-and-annotations.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/text-and-annotations.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-07-30-text-and-annotations.Rmd
+++ b/r/2015-07-30-text-and-annotations.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/text-and-annotations.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Text Mode
 
 ```{r}

--- a/r/2015-07-30-time-series.Rmd
+++ b/r/2015-07-30-time-series.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Dates
 
 ```{r}

--- a/r/2015-07-30-time-series.Rmd
+++ b/r/2015-07-30-time-series.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-11-19-pie-charts.Rmd
+++ b/r/2015-11-19-pie-charts.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-11-19-pie-charts.Rmd
+++ b/r/2015-11-19-pie-charts.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Pie Chart
 
 ```{r}

--- a/r/2015-11-19-shapes.Rmd
+++ b/r/2015-11-19-shapes.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/shape.jpg
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-11-19-shapes.Rmd
+++ b/r/2015-11-19-shapes.Rmd
@@ -20,6 +20,8 @@ knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ### Lines
 
 ```{r}
+library(plotly)
+
 s <- seq.int(0, 15)
 p <- plot_ly(x = ~s, y = ~sin(s), mode = "lines")
 

--- a/r/2015-11-19-shapes.Rmd
+++ b/r/2015-11-19-shapes.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/shape.jpg
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Lines
 
 ```{r}

--- a/r/2015-12-31-network-graph.Rmd
+++ b/r/2015-12-31-network-graph.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/net.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2015-12-31-network-graph.Rmd
+++ b/r/2015-12-31-network-graph.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/net.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Read Graph File
 We are using the well-known social network of `Zachary's karate club`. GML format file can be collected from [here](https://gist.github.com/pravj/9168fe52823c1702a07b).
 

--- a/r/2016-02-22-error-bars.Rmd
+++ b/r/2016-02-22-error-bars.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-02-22-error-bars.Rmd
+++ b/r/2016-02-22-error-bars.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Bar Chart with Error Bars
 
 ```{r}

--- a/r/2016-02-25-scattergl-1Million.Rmd
+++ b/r/2016-02-25-scattergl-1Million.Rmd
@@ -13,19 +13,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 # WebGL with 1 Million points 
 
 ```{r}

--- a/r/2016-02-25-scattergl-1Million.Rmd
+++ b/r/2016-02-25-scattergl-1Million.Rmd
@@ -14,12 +14,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-02-25-scattergl-timeseries.Rmd
+++ b/r/2016-02-25-scattergl-timeseries.Rmd
@@ -14,12 +14,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-02-25-scattergl-timeseries.Rmd
+++ b/r/2016-02-25-scattergl-timeseries.Rmd
@@ -13,19 +13,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 # WebGL for time series data (24381 points)
 
 ```{r}

--- a/r/2016-02-25-scattergl.Rmd
+++ b/r/2016-02-25-scattergl.Rmd
@@ -19,12 +19,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-02-25-scattergl.Rmd
+++ b/r/2016-02-25-scattergl.Rmd
@@ -18,19 +18,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 # WebGL vs SVG in R
 
 Recent versions of the R package include the `toWebGL()` function, which converts any eligible SVG graph into a WebGL plot. With WebGL, we can render way more elements in the browser.

--- a/r/2016-06-16-3d-mesh-plots.Rmd
+++ b/r/2016-06-16-3d-mesh-plots.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/3d-mesh.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-06-16-3d-mesh-plots.Rmd
+++ b/r/2016-06-16-3d-mesh-plots.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/3d-mesh.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic 3D Mesh Plot
 
 ```{r}

--- a/r/2016-06-17-3d-tri-surf.Rmd
+++ b/r/2016-06-17-3d-tri-surf.Rmd
@@ -15,12 +15,7 @@ thumbnail: thumbnail/trisurf.jpg
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-06-17-3d-tri-surf.Rmd
+++ b/r/2016-06-17-3d-tri-surf.Rmd
@@ -15,16 +15,6 @@ thumbnail: thumbnail/trisurf.jpg
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
 ### Basic Tri-Surf Plot
 
 ```{r}

--- a/r/2016-07-07-logos.Rmd
+++ b/r/2016-07-07-logos.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/orca-management.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-07-07-logos.Rmd
+++ b/r/2016-07-07-logos.Rmd
@@ -16,16 +16,6 @@ thumbnail: thumbnail/orca-management.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
 ### Embed Logos on a Graph
 
 ```{r}

--- a/r/2016-08-10-dropdowns.Rmd
+++ b/r/2016-08-10-dropdowns.Rmd
@@ -16,16 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
 ### Simple Dropdown Menu Example
 
 ```{r}

--- a/r/2016-08-10-dropdowns.Rmd
+++ b/r/2016-08-10-dropdowns.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-09-29-line.Rmd
+++ b/r/2016-09-29-line.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Line Plot
 
 ```{r}

--- a/r/2016-09-29-line.Rmd
+++ b/r/2016-09-29-line.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-10-06-horizontal-bar-charts.Rmd
+++ b/r/2016-10-06-horizontal-bar-charts.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Horizontal Bar Chart
 
 ```{r}

--- a/r/2016-10-06-horizontal-bar-charts.Rmd
+++ b/r/2016-10-06-horizontal-bar-charts.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2016-11-28-gantt.Rmd
+++ b/r/2016-11-28-gantt.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Gantt Chart
 
 ```{r}

--- a/r/2016-11-28-gantt.Rmd
+++ b/r/2016-11-28-gantt.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-04-3d-axes.Rmd
+++ b/r/2017-01-04-3d-axes.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/theming-and-templates.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-04-3d-axes.Rmd
+++ b/r/2017-01-04-3d-axes.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/theming-and-templates.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Range of Axes
 
 ```{r}

--- a/r/2017-01-04-3d-subplots.Rmd
+++ b/r/2017-01-04-3d-subplots.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### 3D Subplot
 
 ```{r}

--- a/r/2017-01-04-3d-subplots.Rmd
+++ b/r/2017-01-04-3d-subplots.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-13-mixed-subplot.Rmd
+++ b/r/2017-01-13-mixed-subplot.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Mixed Subplot
 
 ```{r}

--- a/r/2017-01-13-mixed-subplot.Rmd
+++ b/r/2017-01-13-mixed-subplot.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-19-buttons.Rmd
+++ b/r/2017-01-19-buttons.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-19-buttons.Rmd
+++ b/r/2017-01-19-buttons.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Methods
 
 The [updatemenu method](https://plot.ly/r/reference/#layout-updatemenus-buttons-method) determines which [plotly.js](https://plot.ly/javascript/plotlyjs-function-reference/) function will be used to modify the chart. There are 4 possible methods:

--- a/r/2017-01-19-sliders.Rmd
+++ b/r/2017-01-19-sliders.Rmd
@@ -16,17 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Slider Control
 
 ```{r}

--- a/r/2017-01-19-sliders.Rmd
+++ b/r/2017-01-19-sliders.Rmd
@@ -16,12 +16,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-20-font-styles.Rmd
+++ b/r/2017-01-20-font-styles.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/text-and-annotations.png
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-20-font-styles.Rmd
+++ b/r/2017-01-20-font-styles.Rmd
@@ -16,19 +16,6 @@ thumbnail: thumbnail/text-and-annotations.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Global Font Properties
 
 ```{r}

--- a/r/2017-01-20-ternary-plots.Rmd
+++ b/r/2017-01-20-ternary-plots.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/ternary.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-01-20-ternary-plots.Rmd
+++ b/r/2017-01-20-ternary-plots.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/ternary.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Ternary Plot with Markers
 
 ```{r}

--- a/r/2017-02-03-candlestick.Rmd
+++ b/r/2017-02-03-candlestick.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-02-03-candlestick.Rmd
+++ b/r/2017-02-03-candlestick.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Candlestick
 
 ```{r}

--- a/r/2017-02-03-ohlc-charts.Rmd
+++ b/r/2017-02-03-ohlc-charts.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-02-03-ohlc-charts.Rmd
+++ b/r/2017-02-03-ohlc-charts.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic OHLC Chart
 
 ```{r}

--- a/r/2017-02-27-scattermapbox.Rmd
+++ b/r/2017-02-27-scattermapbox.Rmd
@@ -16,19 +16,6 @@ thumbnail: thumbnail/scatter-mapbox.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Mapbox Access Token
 
 To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/r/mapbox-layers/) documentation for more information. If you're using a Chart Studio Enterprise server, please see additional instructions [here](https://help.plot.ly/mapbox-atlas).

--- a/r/2017-02-27-scattermapbox.Rmd
+++ b/r/2017-02-27-scattermapbox.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/scatter-mapbox.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-03-07-parcoords.Rmd
+++ b/r/2017-03-07-parcoords.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/parcoords.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-03-07-parcoords.Rmd
+++ b/r/2017-03-07-parcoords.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/parcoords.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Adding Dimensions
 
 ```{r}

--- a/r/2017-04-12-county-level-choropleth.Rmd
+++ b/r/2017-04-12-county-level-choropleth.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/county-level-choropleth.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-04-12-county-level-choropleth.Rmd
+++ b/r/2017-04-12-county-level-choropleth.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/county-level-choropleth.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Mapbox Access Token
 
 To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/r/mapbox-layers/) documentation for more information. If you're using a Chart Studio Enterprise server, please see additional instructions [here](https://help.plot.ly/mapbox-atlas).

--- a/r/2017-04-24-carpet-plot.Rmd
+++ b/r/2017-04-24-carpet-plot.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/carpet.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Set the Coordinates 
 
 To set the `x` and `y` coordinates use `x` and `y` attributes. If `x` coorindate values are ommitted a cheater plot will be created.

--- a/r/2017-04-24-carpet-plot.Rmd
+++ b/r/2017-04-24-carpet-plot.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/carpet.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-04-24-contourcarpet.Rmd
+++ b/r/2017-04-24-contourcarpet.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/contourcarpet.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-04-24-contourcarpet.Rmd
+++ b/r/2017-04-24-contourcarpet.Rmd
@@ -16,18 +16,6 @@ thumbnail: thumbnail/contourcarpet.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
-
 ### Basic Carpet Plot
 
 Set the `x` and `y` coorindates, using `x` and `y` attributes. If `x` coorindate values are ommitted a cheater plot will be created. To save parameter values use `a` and `b` attributes. To make changes to the axes, use `aaxis` or `baxis` attributes. For a more detailed list of axes attributes refer to [R reference](https://plot.ly/r/reference/#contourcarpet-aaxis).

--- a/r/2017-04-24-scattercarpet.Rmd
+++ b/r/2017-04-24-scattercarpet.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/scattercarpet.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-04-24-scattercarpet.Rmd
+++ b/r/2017-04-24-scattercarpet.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/scattercarpet.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Carpet Plot
 
 ```{r}

--- a/r/2017-05-19-sankey.Rmd
+++ b/r/2017-05-19-sankey.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/sankey.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Sankey Diagram
 
 ```{r}

--- a/r/2017-05-19-sankey.Rmd
+++ b/r/2017-05-19-sankey.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/sankey.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-05-25-dot-plots.Rmd
+++ b/r/2017-05-25-dot-plots.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 # Dot and Dumbbell Plots
 
 ```{r}

--- a/r/2017-05-25-dot-plots.Rmd
+++ b/r/2017-05-25-dot-plots.Rmd
@@ -18,6 +18,8 @@ knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 # Dot and Dumbbell Plots
 
 ```{r}
+library(plotly)
+
 s <- read.csv("https://raw.githubusercontent.com/plotly/datasets/master/school_earnings.csv")
 s <- s[order(s$Men), ]
 

--- a/r/2017-05-25-dot-plots.Rmd
+++ b/r/2017-05-25-dot-plots.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-05-26-ternary-contour.Rmd
+++ b/r/2017-05-26-ternary-contour.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/ternary-contour.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-05-26-ternary-contour.Rmd
+++ b/r/2017-05-26-ternary-contour.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/ternary-contour.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Terary Contour Plot
 
 ```{r}

--- a/r/2017-05-28-cumulative-animations.Rmd
+++ b/r/2017-05-28-cumulative-animations.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-05-28-cumulative-animations.Rmd
+++ b/r/2017-05-28-cumulative-animations.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Frames
 
 Now, along with `data` and `layout`, `frames` is added to the keys that `figure` allows. Your `frames` key points to a list of figures, each of which will be cycled through upon instantiation of the plot.

--- a/r/2017-05-28-intro-to-animations.Rmd
+++ b/r/2017-05-28-intro-to-animations.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-05-28-intro-to-animations.Rmd
+++ b/r/2017-05-28-intro-to-animations.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Frames
 
 Now, along with `data` and `layout`, `frames` is added to the keys that `figure` allows. Your `frames` key points to a list of figures, each of which will be cycled through upon instantiation of the plot.

--- a/r/2017-08-31-colorscales.Rmd
+++ b/r/2017-08-31-colorscales.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-08-31-colorscales.Rmd
+++ b/r/2017-08-31-colorscales.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Colorscale for Scatter Plots
 
 ```{r}

--- a/r/2017-10-23-aggregations.Rmd
+++ b/r/2017-10-23-aggregations.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-10-23-aggregations.Rmd
+++ b/r/2017-10-23-aggregations.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Introduction
 
 Aggregates are a type of transform that can be applied to values in a given expression. Available aggregations are:

--- a/r/2017-10-26-filter.Rmd
+++ b/r/2017-10-26-filter.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-10-26-filter.Rmd
+++ b/r/2017-10-26-filter.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic Example
 
 ```{r}

--- a/r/2017-10-26-groupby.Rmd
+++ b/r/2017-10-26-groupby.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2017-10-26-groupby.Rmd
+++ b/r/2017-10-26-groupby.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic Example
 
 ```{r}

--- a/r/2018-01-16-violin.Rmd
+++ b/r/2018-01-16-violin.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic Violin Plot
 
 ```{r}

--- a/r/2018-01-16-violin.Rmd
+++ b/r/2018-01-16-violin.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-01-29-hover-text-and-formatting.Rmd
+++ b/r/2018-01-29-hover-text-and-formatting.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-01-29-hover-text-and-formatting.Rmd
+++ b/r/2018-01-29-hover-text-and-formatting.Rmd
@@ -16,19 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Add Hover Text
 
 ```{r}

--- a/r/2018-01-30-histogram2dcontour.Rmd
+++ b/r/2018-01-30-histogram2dcontour.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic 2D Histogram Contour
 
 ```{r}

--- a/r/2018-01-30-histogram2dcontour.Rmd
+++ b/r/2018-01-30-histogram2dcontour.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-02-13-scatterpolar.Rmd
+++ b/r/2018-02-13-scatterpolar.Rmd
@@ -16,19 +16,6 @@ thumbnail: thumbnail/polar.gif
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Polar Charts 1.0
 
 Looking for the old polar chart docs? See [legacy polar charts](https://plot.ly/r/legacy-polar-chart/)

--- a/r/2018-02-13-scatterpolar.Rmd
+++ b/r/2018-02-13-scatterpolar.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/polar.gif
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-02-23-radar-charts.Rmd
+++ b/r/2018-02-23-radar-charts.Rmd
@@ -15,19 +15,6 @@ thumbnail: thumbnail/radar.gif
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Basic Radar Charts
 
 ```{r}

--- a/r/2018-02-23-radar-charts.Rmd
+++ b/r/2018-02-23-radar-charts.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/radar.gif
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-03-15-marker-style.Rmd
+++ b/r/2018-03-15-marker-style.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/marker-style.gif
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-03-15-marker-style.Rmd
+++ b/r/2018-03-15-marker-style.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/marker-style.gif
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Add Marker Border
 In order to make markers distinct, you can add a border to the markers. This can be achieved by adding the line dict to the marker dict. For example, `marker:{..., line: {...}}`.
 

--- a/r/2018-05-23-splom.Rmd
+++ b/r/2018-05-23-splom.Rmd
@@ -22,7 +22,7 @@ The Plotly splom trace implementation for the scaterplot matrix does not require
 
 A trace of type splom is defined as follows:
 
-``` {r, results = 'hide', eval=FALSE}
+```{r, results = 'hide', eval=FALSE}
 p <- plot_ly() %>%
   add_trace(
     dimensions = list(
@@ -45,7 +45,7 @@ marker sets the markers attributes in all scatter plots.
 
 #### Splom of the Iris data set
 
-``` {r, results = 'hide'}
+```{r, results = 'hide'}
 library(plotly)
 
 df <- read.csv('https://raw.githubusercontent.com/plotly/datasets/master/iris-data.csv')
@@ -55,7 +55,7 @@ The Iris dataset contains four data variables, sepal length, sepal width, petal 
 
 Define a discrete colorscale with three colors corresponding to the three flower classes:
 
-``` {r, results = 'hide'}
+```{r, results = 'hide'}
 pl_colorscale=list(c(0.0, '#19d3f3'),
                c(0.333, '#19d3f3'),
                c(0.333, '#e763fa'),

--- a/r/2018-05-23-splom.Rmd
+++ b/r/2018-05-23-splom.Rmd
@@ -15,19 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### Splom trace
 A scaterplot matrix is a matrix associated to n numerical arrays (data variables), $X^1,X^2,.,X_n$ , of the same length. The cell (i,j) of such a matrix displays the scatter plot of the variable Xi versus Xj ,
 

--- a/r/2018-05-23-splom.Rmd
+++ b/r/2018-05-23-splom.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-06-06-cone.Rmd
+++ b/r/2018-06-06-cone.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 ### Basic 3D Cone
 
-``` {r}
+```{r}
 library(plotly)
 
 p <- plot_ly(

--- a/r/2018-06-06-cone.Rmd
+++ b/r/2018-06-06-cone.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/3dcone.png
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-06-06-cone.Rmd
+++ b/r/2018-06-06-cone.Rmd
@@ -16,19 +16,6 @@ thumbnail: thumbnail/3dcone.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic 3D Cone
 
 ``` {r}

--- a/r/2018-06-22-sf.Rmd
+++ b/r/2018-06-22-sf.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/sf.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-06-22-sf.Rmd
+++ b/r/2018-06-22-sf.Rmd
@@ -15,19 +15,6 @@ thumbnail: thumbnail/sf.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Introduction
 
 In order to complete the examples below, you'll require installing additional packages (`install.packages("packageName")`):

--- a/r/2018-06-22-sf.Rmd
+++ b/r/2018-06-22-sf.Rmd
@@ -28,7 +28,7 @@ To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public 
 
 ### Basic sf
 
-``` {r}
+```{r}
 library(plotly)
 library(sf)
 
@@ -41,7 +41,7 @@ p
 
 You can also use `plot_geo`:
 
-``` {r}
+```{r}
 library(plotly)
 library(sf)
 
@@ -54,7 +54,7 @@ p
 
 Or `plot_mapbox`:
 
-``` {r}
+```{r}
 library(plotly)
 library(sf)
 

--- a/r/2018-07-02-locales.Rmd
+++ b/r/2018-07-02-locales.Rmd
@@ -16,19 +16,6 @@ thumbnail: thumbnail/mapbox-layers.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Setting Locale
 To change the localization, you can use the `locale` argument in the `config()` function. 
 

--- a/r/2018-07-02-locales.Rmd
+++ b/r/2018-07-02-locales.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/mapbox-layers.png
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-07-02-locales.Rmd
+++ b/r/2018-07-02-locales.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ### Setting Locale
 To change the localization, you can use the `locale` argument in the `config()` function. 
 
-``` {r, results = 'hide'}
+```{r, results = 'hide'}
 library(plotly)
 
 x <- seq.Date(Sys.Date(), Sys.Date() + 360, by = "day")

--- a/r/2018-07-19-streamtube.Rmd
+++ b/r/2018-07-19-streamtube.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/streamtube.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
-
 #### Introduction
 
 In streamtube plots, attributes inlcude `x`, `y`, and `z`, which set the coorindates of the vector field, and `u`, `v`, and `w`, which sets the x, y, and z components of the vector field. Additionally, you can use `starts` to determine the streamtube's starting position. Lastly, `maxdisplayed` determines the maximum segments displayed in a streamtube.  

--- a/r/2018-07-19-streamtube.Rmd
+++ b/r/2018-07-19-streamtube.Rmd
@@ -15,12 +15,7 @@ thumbnail: thumbnail/streamtube.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-08-03-heatmap-webgl.Rmd
+++ b/r/2018-08-03-heatmap-webgl.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/heatmap-webgl.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-08-03-heatmap-webgl.Rmd
+++ b/r/2018-08-03-heatmap-webgl.Rmd
@@ -15,19 +15,6 @@ thumbnail: thumbnail/heatmap-webgl.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 #### WebGL Heatmap from an Image
 
 ```{r}

--- a/r/2018-08-09-webgl-text-and-annotations.Rmd
+++ b/r/2018-08-09-webgl-text-and-annotations.Rmd
@@ -16,18 +16,6 @@ thumbnail: thumbnail/webgl.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
-
 ### Heatmap with Annotations
 
 ```{r}

--- a/r/2018-08-09-webgl-text-and-annotations.Rmd
+++ b/r/2018-08-09-webgl-text-and-annotations.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/webgl.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-10-03-colorway.Rmd
+++ b/r/2018-10-03-colorway.Rmd
@@ -16,19 +16,6 @@ thumbnail: thumbnail/colorway.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Set Default Trace Colors with `colorway`
 
 ```{r}

--- a/r/2018-10-03-colorway.Rmd
+++ b/r/2018-10-03-colorway.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/colorway.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-10-11-3d-hover.Rmd
+++ b/r/2018-10-11-3d-hover.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/hover-text.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Customize Hover for Spikelines
 
 By default, Plotly's 3D plots display lines called "spikelines" while hovering over a point.

--- a/r/2018-10-11-3d-hover.Rmd
+++ b/r/2018-10-11-3d-hover.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/hover-text.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-10-11-3d-hover.Rmd
+++ b/r/2018-10-11-3d-hover.Rmd
@@ -82,8 +82,8 @@ p <- plot_ly(z = ~volcano) %>% add_surface(
 
 
 p
-``` 
+```
 
-#Reference
+# Reference
 
 See [https://plot.ly/r/reference/#layout-scene-xaxis](https://plot.ly/r/reference/#layout-scene-xaxis) and [https://plot.ly/r/reference/#surface-contours](https://plot.ly/r/reference/#surface-contours) for more information and options!

--- a/r/2018-11-22-3d-surface-lighting.Rmd
+++ b/r/2018-11-22-3d-surface-lighting.Rmd
@@ -19,6 +19,8 @@ knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ### Ambient
 
 ```{r}
+library(plotly)
+
 p1 <- plot_ly(z = ~volcano, scene='scene1', lighting = list(ambient = 0.2)) %>%
   add_surface(showscale=FALSE)
 
@@ -40,6 +42,8 @@ p
 ### Roughness
 
 ```{r}
+library(plotly)
+
 p1 <- plot_ly(z = ~volcano, scene='scene1', lighting = list(roughness = 0.1)) %>%
   add_surface(showscale=FALSE)
 
@@ -61,6 +65,8 @@ p
 ### Diffuse
 
 ```{r}
+library(plotly)
+
 p1 <- plot_ly(z = ~volcano, scene='scene1', lighting = list(diffuse = 0.1)) %>%
   add_surface(showscale=FALSE)
 
@@ -82,6 +88,8 @@ p
 ### Specular
 
 ```{r}
+library(plotly)
+
 p1 <- plot_ly(z = ~volcano, scene='scene1', lighting = list(specular = 0.1)) %>%
   add_surface(showscale=FALSE)
 
@@ -103,6 +111,8 @@ p
 ### Fresnel
 
 ```{r}
+library(plotly)
+
 p1 <- plot_ly(z = ~volcano, scene='scene1', lighting = list(fresnel = 0.1)) %>%
   add_surface(showscale=FALSE)
 

--- a/r/2018-11-22-3d-surface-lighting.Rmd
+++ b/r/2018-11-22-3d-surface-lighting.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/3d-surface-color.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Ambient
 
 ```{r}

--- a/r/2018-11-22-3d-surface-lighting.Rmd
+++ b/r/2018-11-22-3d-surface-lighting.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/3d-surface-color.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-11-23-table.Rmd
+++ b/r/2018-11-23-table.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2018-11-23-table.Rmd
+++ b/r/2018-11-23-table.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Table
 
 ```{r}

--- a/r/2019-03-08-tick-formatting.Rmd
+++ b/r/2019-03-08-tick-formatting.Rmd
@@ -16,12 +16,7 @@ thumbnail: thumbnail/hover.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-03-08-tick-formatting.Rmd
+++ b/r/2019-03-08-tick-formatting.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/hover.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Tickmode - Linear
 
 ```{r}

--- a/r/2019-04-12-sunburst-chart.Rmd
+++ b/r/2019-04-12-sunburst-chart.Rmd
@@ -15,17 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Sunburst Chart
 
 ```{r}

--- a/r/2019-04-12-sunburst-chart.Rmd
+++ b/r/2019-04-12-sunburst-chart.Rmd
@@ -15,12 +15,7 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-04-16-isosurface.Rmd
+++ b/r/2019-04-16-isosurface.Rmd
@@ -15,12 +15,7 @@ thumbnail: thumbnail/isosurface.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-04-16-isosurface.Rmd
+++ b/r/2019-04-16-isosurface.Rmd
@@ -15,18 +15,6 @@ thumbnail: thumbnail/isosurface.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
-
 #### Basic Isosurface Plot
 
 ```{r}

--- a/r/2019-05-03-waterfall-charts.Rmd
+++ b/r/2019-05-03-waterfall-charts.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-05-03-waterfall-charts.Rmd
+++ b/r/2019-05-03-waterfall-charts.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Waterfall Chart
 
 ```{r}

--- a/r/2019-09-17-funnel-charts.Rmd
+++ b/r/2019-09-17-funnel-charts.Rmd
@@ -23,12 +23,7 @@ knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 devtools::install_github("ropensci/plotly")
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-09-17-funnel-charts.Rmd
+++ b/r/2019-09-17-funnel-charts.Rmd
@@ -22,18 +22,6 @@ knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 # Install plotly from github for funnel plot
 devtools::install_github("ropensci/plotly")
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Introduction
 Funnel charts are often used to represent data in different stages of a business process. It’s an important mechanism in Business Intelligence to identify potential problem areas of a process. For example, it’s used to observe the revenue or loss in a sales process for each stage, and displays values that are decreasing progressively. Each stage is illustrated as a percentage of the total of all values.
 

--- a/r/2019-09-20-filled-area-on-mapbox.Rmd
+++ b/r/2019-09-20-filled-area-on-mapbox.Rmd
@@ -16,17 +16,6 @@ thumbnail: thumbnail/area.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
 ### Mapbox Access Token
 
 To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/r/mapbox-layers/) documentation for more information. If you're using a Chart Studio Enterprise server, please see additional instructions [here](https://help.plot.ly/mapbox-atlas).

--- a/r/2019-09-20-filled-area-on-mapbox.Rmd
+++ b/r/2019-09-20-filled-area-on-mapbox.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/area.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-09-20-mapbox-layers.Rmd
+++ b/r/2019-09-20-mapbox-layers.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/mapbox-layers.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-09-20-mapbox-layers.Rmd
+++ b/r/2019-09-20-mapbox-layers.Rmd
@@ -17,17 +17,6 @@ thumbnail: thumbnail/mapbox-layers.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### How Layers Work in Mapbox Maps
 
 If your figure contains one or more traces of type `scattermapbox`, `choroplethmapbox` or `densitymapbox`, the `layout` of your figure contains configuration information for the map itself. 

--- a/r/2019-09-23-mapbox-density.Rmd
+++ b/r/2019-09-23-mapbox-density.Rmd
@@ -16,18 +16,6 @@ thumbnail: thumbnail/mapbox-density.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Mapbox Access Token
 
 To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/r/mapbox-layers/) documentation for more information. If you're using a Chart Studio Enterprise server, please see additional instructions [here](https://help.plot.ly/mapbox-atlas).

--- a/r/2019-09-23-mapbox-density.Rmd
+++ b/r/2019-09-23-mapbox-density.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/mapbox-density.png
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-09-26-bullet-charts.Rmd
+++ b/r/2019-09-26-bullet-charts.Rmd
@@ -15,18 +15,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Bullet Charts
 
   Stephen Few's Bullet Chart was invented to replace dashboard [gauges](https://plot.ly/r/gauge-charts/) and meters, combining both types of charts into simple bar charts with qualitative bars (steps), quantitative bar (bar) and performance line (threshold); all into one simple layout.

--- a/r/2019-09-26-bullet-charts.Rmd
+++ b/r/2019-09-26-bullet-charts.Rmd
@@ -16,12 +16,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-09-26-gauge-charts.Rmd
+++ b/r/2019-09-26-gauge-charts.Rmd
@@ -17,12 +17,7 @@ output:
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2019-09-26-gauge-charts.Rmd
+++ b/r/2019-09-26-gauge-charts.Rmd
@@ -16,18 +16,6 @@ output:
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Basic Gauge
 
   A radial gauge chart has a circular arc, which displays a single value to estimate progress toward a goal.

--- a/r/2019-09-27-lines-on-mapbox.Rmd
+++ b/r/2019-09-27-lines-on-mapbox.Rmd
@@ -16,18 +16,6 @@ thumbnail: thumbnail/line_mapbox.jpg
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-
-
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
-
 ### Mapbox Access Token
 
 To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/r/mapbox-layers/) documentation for more information. If you're using a Chart Studio Enterprise server, please see additional instructions [here](https://help.plot.ly/mapbox-atlas).

--- a/r/2019-09-27-lines-on-mapbox.Rmd
+++ b/r/2019-09-27-lines-on-mapbox.Rmd
@@ -17,12 +17,7 @@ thumbnail: thumbnail/line_mapbox.jpg
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
 
-### New to Plotly?
 
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
 
 ### Version Check
 

--- a/r/2020-01-20-static-image-export.Rmd
+++ b/r/2020-01-20-static-image-export.Rmd
@@ -39,6 +39,8 @@ The `orca()` function accepts two parameters. The first is the plot to be export
 For example, running the following commands in an R session would export the graph stored in `p` in a file called `surface-plot.svg`:
 
 ```{r, eval = FALSE}
+library(plotly)
+
 if (!require("processx")) install.packages("processx")
 p <- plot_ly(z = ~volcano) %>% add_surface()
 orca(p, "surface-plot.svg")


### PR DESCRIPTION
The purpose of this PR is to remove the `new to plotly` section from r docs in anticipation of that section being added in at the Jekyll layout level in the `documentation` repo. 

addresses https://github.com/plotly/documentation/issues/1653