### PR TITLE
Move chart-studio related docs from documentation repo to here & fixup language around Chart Studio/Plotly

### DIFF
--- a/r/2015-04-09-static-image_r_index.Rmd
+++ b/r/2015-04-09-static-image_r_index.Rmd
@@ -1,0 +1,97 @@
+---
+description: How to export Chart Studio graphs as static images in R. Chart Studio supports exporting to .png,
+  .svg, .jpg, and .pdf file formarts.
+display_as: chart_studio
+language: r
+layout: base
+name: Static Image Export
+order: 2
+output:
+  html_document:
+    keep_md: true
+page_type: example_index
+permalink: r/static-image-export/
+sitemap: false
+thumbnail: thumbnail/png-export.png
+---
+
+```{r, echo = FALSE, message=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning=FALSE)
+Sys.setenv("plotly_username"="RPlotBot")
+Sys.setenv("plotly_api_key"="q0lz6r5efr")
+```
+
+### New to Plotly?
+
+Plotly's R library is free and open source!<br>
+[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
+You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
+We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
+
+### Version Check
+
+Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
+Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
+
+```{r}
+library(plotly)
+packageVersion('plotly')
+```
+
+### Supported Formats
+
+The common image formats: 'PNG', 'JPG/JPEG' are supported. In addition, formats like 'EPS', 'SVG' and 'PDF' are also available for user with a Chart Studio Enterprise subscription. You can get more details about Chart Studio Enterprise on our [here] (https://plot.ly/online-chart-maker/)
+
+**Note:** It is important to note that any figures containing WebGL traces (i.e. of type scattergl, heatmapgl, contourgl, scatter3d, surface, mesh3d, scatterpolargl, cone, streamtube, splom, or parcoords) that are exported in a vector format like SVG, EPS or PDF will include encapsulated rasters instead of vectors for some parts of the image.
+
+To access the image in a particular format, you can either:
+
+* use the `orca()` function. [Orca](https://github.com/plotly/orca) is Plotly's command line applications for generating static images.
+
+* export the image on Chart Studio using `plotly_IMAGE()`.
+
+* append the format extension to the plot url. i.e. the JPG version of the plot: https://plot.ly/~chris/1638 is available at : https://plot.ly/~chris/1638.jpg.
+
+### Export Locally
+
+Version `4.7.900` and above of the `plotly` R package includes the `orca()` function (replacing the `export()` function), which exports images locally, but requires the `processx` package:
+
+```{r, eval = FALSE}
+if (!require("processx")) install.packages("processx")
+
+p <- plot_ly(z = ~volcano) %>% add_surface()
+
+orca(p, "surface-plot.svg")
+```
+
+### Export Using Your Chart Studio Account
+
+Another option is to do image export through your Chart Studio account.
+
+First, you will require the development version of the `plotly` R package. This can be installed using the `devtools::install_github("ropensci/plotly")` command. 
+
+In addition, if you haven't already, let the R package know about your credentials.
+
+
+```{r, eval = FALSE}
+Sys.setenv("plotly_username" = "YOUR USER NAME")
+Sys.setenv("plotly_api_key" = "YOUR API KEY")
+```
+
+This option will export the image through Chart Studio and write the content to a local file `output.png` in your working directory.
+
+```{r}
+library(plotly)
+p <- plot_ly(x = c(1,2,3,4), y = c(2,4,1,3), type = 'scatter', mode = 'lines')
+plotly_IMAGE(p, format = "png", out_file = "output.png")
+```
+
+![](https://images.plot.ly/plotly-documentation/images/output.png)
+
+### Appending File Type to URL
+
+You can also view the static version of any Chart Studio graph by appending `.png`, `.pdf`, `.eps`, or `.svg` to the end of the URL. 
+
+For example, view the static image of <https://plot.ly/~chris/1638> at <https://plot.ly/~chris/1638.png>. 
+
+See [Embedding Graphs in RMarkdown](https://plot.ly/r/embedding-graphs-in-rmarkdown/) for a way to embed these links in RMarkdown (.Rmd) files.

--- a/r/2015-07-30-filenames.Rmd
+++ b/r/2015-07-30-filenames.Rmd
@@ -1,0 +1,59 @@
+---
+description: How to update Chart Studio graphs in R.
+display_as: chart_studio
+language: r
+layout: base
+name: Updating Chart Studio Graphs
+order: 1
+output:
+  html_document:
+    keep_md: true
+page_type: example_index
+permalink: r/file-options/
+thumbnail: thumbnail/horizontal-bar.jpg
+---
+
+```{r, echo = FALSE, message=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning=FALSE)
+```
+### New to Plotly?
+
+Plotly's R library is free and open source!<br>
+[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
+You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
+We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
+
+### Version Check
+
+Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
+Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
+```{r}
+library(plotly)
+packageVersion('plotly')
+```
+
+#### Save Plot to Chart Studio
+To create a Chart Studio figure, use the `api_create()` function.
+
+```{r}
+library(plotly)
+p <- plot_ly(data = iris, x = ~Sepal.Length, y = ~Petal.Length)
+api_create(p)
+```
+
+#### Overwrite Plot
+
+If you don't include a filename, a new plot will be made on your online plotly account. If you want to overwrite a plot (i.e., keep the graph served from the same plotly URL), specify a filename. This implicitly overwrites your plotly graph.
+
+```{r}
+api_create(p, filename = "name-of-my-plotly-file")
+```
+
+#### Save your Plot in a Folder
+If the filename contains "/", it will automatically create a folder in your Chart Studio account. This option is only available for [Chart Studio Enterprise subscripbers](https://plot.ly/online-chart-maker/)
+
+```{r}
+api_create(p, filename="r-docs/name-of-my-chart-studio-file")
+```
+
+View your Chart Studio graphs at [https://plot.ly/organize](https://plot.ly/organize).

--- a/r/2015-07-30-filenames.Rmd
+++ b/r/2015-07-30-filenames.Rmd
@@ -15,6 +15,8 @@ thumbnail: thumbnail/horizontal-bar.jpg
 
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
+Sys.setenv("plotly_username"="RPlotBot")
+Sys.setenv("plotly_api_key"="q0lz6r5efr")
 ```
 ### New to Plotly?
 

--- a/r/2015-07-30-get-requests.Rmd
+++ b/r/2015-07-30-get-requests.Rmd
@@ -1,0 +1,67 @@
+---
+description: How to download Chart Studio users' public graphs and data into R.
+display_as: chart_studio
+language: r
+layout: base
+name: Dowloading Chart Studio Graphs
+order: 6
+output:
+  html_document:
+    keep_md: true
+permalink: r/download-chart-studio-graphs/
+redirect_from:
+- r/get-requests/
+thumbnail: thumbnail/get-requests.jpg
+---
+
+```{r, echo = FALSE, message=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning=FALSE)
+```
+### New to Plotly?
+
+Plotly's R library is free and open source!<br>
+[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
+You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
+We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
+
+### Version Check
+
+Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
+Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
+```{r}
+library(plotly)
+packageVersion('plotly')
+```
+
+### Download Chart Studio Graphs Into R
+
+Download Chart Studio figures directly into R with the `api_download_plot()` function. This takes the `plot_id` of the Chart Studio plot and the `username` of the plot's creator as arguments.
+
+For example, to download [https://plot.ly/~cpsievert/559](https://plot.ly/~cpsievert/559) into R, call:
+
+```{r}
+library(plotly)
+fig <- api_download_plot("559", "cpsievert")
+fig
+```
+
+### Edit The Downloaded Graph
+Once the figure is downloaded, you can edit it. This will create a new figure unless you specify the same filename as the figure that you downloaded.
+
+```{r}
+p <- layout(fig, title = paste("Modified on ", Sys.time()))
+p
+```
+
+### Adding a Trace to a Subplot Figure
+
+```{r}
+fig <- api_download_plot("6343", "chelsea_lyn")
+
+p <- add_lines(fig, x = c(1, 2), y = c(1, 2), xaxis = "x2", yaxis = "y2")
+p
+```
+
+### Reference
+
+See `help("api")`

--- a/r/2015-07-30-get-requests.Rmd
+++ b/r/2015-07-30-get-requests.Rmd
@@ -16,6 +16,8 @@ thumbnail: thumbnail/get-requests.jpg
 
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
+Sys.setenv("plotly_username"="RPlotBot")
+Sys.setenv("plotly_api_key"="q0lz6r5efr")
 ```
 ### New to Plotly?
 

--- a/r/2015-07-30-privacy.Rmd
+++ b/r/2015-07-30-privacy.Rmd
@@ -64,8 +64,8 @@ Below is the URL of the private plot above. Only the owner can view the private 
 ```{r}
 library(plotly)
 p <- plot_ly(x = c(0, 2, 4), y = c(0, 4, 2), type = 'scatter', mode = 'markers+lines')
-chart_link = api_create(p, filename = "secret-graph", sharing = "secret")
-chart_link
+secret_graph = api_create(p, filename = "secret-graph-file", sharing = "secret")
+secret_graph
 ```
 
 Below is the URL of this secret plot. Anyone with the secret link can view this chart. However, it will not appear in the Plotly feed, your profile, or search engines. <br> Try it out:

--- a/r/2015-07-30-privacy.Rmd
+++ b/r/2015-07-30-privacy.Rmd
@@ -1,0 +1,72 @@
+---
+description: How to set the privacy settings of Chart Studio graphs in R.
+display_as: chart_studio
+language: r
+layout: base
+name: Privacy Settings For Chart Studio Graphs in R
+order: 8
+output:
+  html_document:
+    keep_md: true
+permalink: r/privacy/
+thumbnail: thumbnail/privacy.jpg
+---
+
+```{r, echo = FALSE, message=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning = FALSE)
+Sys.setenv("plotly_username"="RPlotBot")
+Sys.setenv("plotly_api_key"="q0lz6r5efr")
+```
+
+### New to Plotly?
+
+Plotly's R library is free and open source!<br>
+[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
+You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
+We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
+
+### Version Check
+Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
+Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
+```{r}
+library(plotly)
+packageVersion('plotly')
+```
+
+#### Default Privacy
+The `plotly` R package renders plots entirely locally by default, but you can also publish these graphs to Chart Studio via the `api_create()` function. 
+
+By default, `api_create()` creates public graphs (which are free to create), but with a [Chart Studio Enterprise](https://plot.ly/online-chart-maker/) you can easily make them private via the `sharing` argument.
+
+### Public Graph
+Please note, this is the default privacy option.
+
+```{r}
+library(plotly)
+p <- plot_ly(x = c(0, 2, 4), y = c(0, 4, 2), type = 'scatter', mode = 'markers+lines')
+chart_link = api_create(p, filename = "public-graph")
+chart_link
+```
+
+Below is the URL of this public plot. Anyone can view public plots even if they are not logged into Plotly. <br> Try it out: [https://plot.ly/~RPlotBot/4545](https://plot.ly/~RPlotBot/4545)
+
+### Private Graph
+```{r}
+library(plotly)
+p <- plot_ly(x = c(0, 2, 4), y = c(0, 4, 2), type = 'scatter', mode = 'markers+lines')
+chart_link = api_create(p, filename = "private-graph", sharing = "private")
+chart_link
+```
+
+Below is the URL of the private plot above. Only the owner can view the private plot. You won't be able to view this plot. <br> Try it out: [https://plot.ly/~RPlotBot/4549/](https://plot.ly/~RPlotBot/4549/)
+
+### Secret Graph
+```{r}
+library(plotly)
+p <- plot_ly(x = c(0, 2, 4), y = c(0, 4, 2), type = 'scatter', mode = 'markers+lines')
+chart_link = api_create(p, filename = "secret-graph", sharing = "secret")
+chart_link
+```
+
+Below is the URL of this secret plot. Anyone with the secret link can view this chart. However, it will not appear in the Plotly feed, your profile, or search engines. <br> Try it out:
+[https://plot.ly/~RPlotBot/4553/?share_key=62AMQ8YBpZebu6Y5OYsukj](https://plot.ly/~RPlotBot/4553/?share_key=62AMQ8YBpZebu6Y5OYsukj)

--- a/r/2015-08-10-knitr.Rmd
+++ b/r/2015-08-10-knitr.Rmd
@@ -1,0 +1,94 @@
+---
+description: How to embed R graphs in RMarkdown files.
+display_as: chart_studio
+language: r
+layout: base
+name: Embedding R Graphs in RMarkdown Files
+order: 3
+output:
+  html_document:
+    highlight: null
+    keep_md: true
+    theme: null
+page_type: example_index
+permalink: r/embedding-graphs-in-rmarkdown/
+redirect_from:
+- r/embedding-plotly-graphs-in-HTML
+- r/knitr/
+thumbnail: thumbnail/ipythonnb.jpg
+---
+
+```{r, echo = FALSE, message=FALSE}
+knitr::opts_chunk$set(message = FALSE)
+```
+### New to Plotly?
+
+Plotly's R library is free and open source!<br>
+[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
+You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
+We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
+
+### Version Check
+
+Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
+Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
+```{r}
+library(plotly)
+packageVersion('plotly')
+```
+
+### Embedding R Graphs in RMarkdown files
+
+If you are using [RMarkdown](http://rmarkdown.rstudio.com/) with HTML output, printing a `plotly` object in a code chunk will result in an interactive HTML graph. When using RMarkdown with non-HTML output, printing a `plotly` object will result in a `.png` screenshot of the graph.
+
+```{r}
+library(plotly)
+p <- plot_ly(economics, x = ~date, y = ~unemploy / pop)
+p
+```
+
+Sometimes, you may want to print a _list_ of plotly objects. If, for some reason, you don't want to use the [`subplot()` function](https://plot.ly/r/subplots/), you can print a list of htmlwidgets in a single code chunk using the `tagList()` function from the **htmltools** package:
+
+```{r}
+htmltools::tagList(list(p, p))
+```
+
+Another way to print multiple objects is by using a `lapply`:
+
+```{r}
+library(plotly)
+
+htmltools::tagList(lapply(1:3, function(x) { plot_ly(x = rnorm(10)) }))
+```
+
+Alternatively, you can use for loops:
+
+```{r}
+library(plotly)
+
+l <- htmltools::tagList()
+for (i in 1:3) {
+  l[[i]] <- plot_ly(x = rnorm(10))
+}
+l
+```
+
+### Embedding Chart Studio Graphs in RMarkdown Files
+
+When you publish your plots to Chart Studio via the `api_create()` function, a figure object is returned. 
+
+When a figure object is printed in an RMarkdown document, it embeds the figure as an `iframe`, displaying the plot as it appears on your Chart Studio account.
+
+```{r, echo="FALSE", results='hide'}
+f <- api_create(p)
+class(f)
+f
+```
+
+You can control the height/width of that iframe through the `height`/`width` [knitr chunk options](http://yihui.name/knitr/options/), but the figure object also contains the relevant url so you complete control over embedding your figure. 
+
+This [post](http://help.plot.ly/embed-graphs-in-websites/) has more details on how to embed Chart Studio graphs within HTML iframes, but you could also use Chart Studio's built-in image export by simply adding a `.png` (or similar) extension.
+
+```{r}
+htmltools::tags$img(src = paste0(f[["url"]], ".png"))
+```

--- a/r/2015-08-10-knitr.Rmd
+++ b/r/2015-08-10-knitr.Rmd
@@ -20,6 +20,8 @@ thumbnail: thumbnail/ipythonnb.jpg
 
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE)
+Sys.setenv("plotly_username"="RPlotBot")
+Sys.setenv("plotly_api_key"="q0lz6r5efr")
 ```
 ### New to Plotly?
 

--- a/r/2017-07-17-configuration-options.Rmd
+++ b/r/2017-07-17-configuration-options.Rmd
@@ -56,6 +56,6 @@ htmlwidgets::saveWidget(config(p, displayModeBar = FALSE), "graph.html")
 
 #### Reference
 Arguments are documented [here](https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js).
-```{r, results = 'hide'}
+```r
 ?config
 ```

--- a/r/2017-07-17-configuration-options.Rmd
+++ b/r/2017-07-17-configuration-options.Rmd
@@ -1,0 +1,61 @@
+---
+name: Embedded Chart Studio Graph Configuration Options 
+permalink: r/configuration-options/
+description: How to set configuration options of embedded Chart Studio graphs in R. Examples of both online and offline configurations.
+layout: base
+language: r
+thumbnail: thumbnail/modebar-icons.png
+display_as: chart_studio
+order: 7
+output:
+  html_document:
+    keep_md: true
+---
+
+```{r, echo = FALSE, message=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning=FALSE)
+```
+### New to Plotly?
+
+Plotly's R library is free and open source!<br>
+[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
+You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
+We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
+
+### Version Check
+
+Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
+Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
+```{r}
+library(plotly)
+packageVersion('plotly')
+```
+
+#### Online Configuration Options 
+
+Configuration options for graphs created with the `plotly` R package are overridden when those graphs are published to Chart Studio using the `api_create()` function. 
+
+To set configutation options for charts published to Chart STudio, you can edit the plot's embed url. 
+
+Visit our embed tutorial: [click here](http://help.plot.ly/embed-graphs-in-websites/#step-8-customize-the-iframe) for more information on customizing the embed url to remove the "Edit Chart" link, hide the modebar, or autosize the plot.
+
+#### Offline Configuration Options 
+
+Add the 'Edit Chart' link:
+```{r, results = 'hide'}
+library(plotly)
+p <- plot_ly(data = iris, x = ~Sepal.Length, y = ~Petal.Length)
+
+htmlwidgets::saveWidget(config(p, showLink = T), "graph.html")
+```
+
+Remove the 'mode bar':
+```{r, results = 'hide'}
+htmlwidgets::saveWidget(config(p, displayModeBar = FALSE), "graph.html")
+```
+
+#### Reference
+Arguments are documented [here](https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js).
+```{r, results = 'hide'}
+?config
+```


### PR DESCRIPTION
The purpose of this PR is to move these files from the `documentation` repo to this one, while updating them docs to make explicit that they are about Chart Studio. 