### PR TITLE
add standalone orca doc

### DIFF
--- a/r/2020-01-20-static-image-export.Rmd
+++ b/r/2020-01-20-static-image-export.Rmd
@@ -39,6 +39,10 @@ With the `plotly` R package, you can export graphs you create as static images i
 
 **Note** Orca runs entirely locally and does not require internet access. No network requests are made to the Chart Studio or any other web service when you invoke the `orca()` function to export static images in your R session. 
 
+### Install Orca
+
+Please follow the installation instructions which can be found on [Orca's GitHub Page](https://github.com/plotly/orca#installation).
+
 ### Export R Graphs As Static Images Using `orca()`
 
 To use Orca to export static images of the graphs you create with the `plotly` R package, you can use the built-in `orca()` function in versions `4.7.900` and above. 
@@ -49,7 +53,7 @@ The `orca()` function accepts two parameters. The first is the plot to be export
 
 For example, running the following commands in an R session would export the graph stored in `p` in a file called `surface-plot.svg`:
 
-```{r, eval = FALSE}
+```{r, eval = TRUE}
 if (!require("processx")) install.packages("processx")
 p <- plot_ly(z = ~volcano) %>% add_surface()
 orca(p, "surface-plot.svg")

--- a/r/2020-01-20-static-image-export.Rmd
+++ b/r/2020-01-20-static-image-export.Rmd
@@ -9,7 +9,7 @@ output:
   html_document:
     keep_md: true
 page_type: u-guide
-permalink: r/image-export-orca/
+permalink: r/static-image-export/
 thumbnail: thumbnail/sizing.png
 ---
 
@@ -31,18 +31,23 @@ Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-abov
 library(plotly)
 packageVersion('plotly')
 ```
+### Supported File Formats
+
+With the `plotly` R package, you can export graphs you create as static images in the `.png`, `.jpg`/`.jpeg`, `.eps`, `.svg`, and/or `.pdf` formats using[Orca](https://github.com/plotly/orca), an open source command line tool for generating static images of graphs created with [Plotly's graphing libraries](https://plot.ly/graphing-libraries).  
+
+**Note:** It is important to be aware that R graphs containing WebGL-based traces (i.e. of type `scattergl`, `heatmapgl`, `contourgl`, `scatter3d`, `surface`, `mesh3d`, `scatterpolargl`, `cone`, `streamtube`, `splom`, and/or `parcoords`) will include encapsulated rasters instead of vectors for some parts of the image if they are exported as static images in a vector format like `.eps`, `.svg`, and/or `.pdf`.
+
+**Note** Orca runs entirely locally and does not require internet access. No network requests are made to the Chart Studio or any other web service when you invoke the `orca()` function to export static images in your R session. 
 
 ### Export R Graphs As Static Images Using `orca()`
 
-[Orca](https://github.com/plotly/orca) is an open source command line tool for generating static images of graphs created with [Plotly's graphing libraries](https://plot.ly/graphing-libraries). 
+To use Orca to export static images of the graphs you create with the `plotly` R package, you can use the built-in `orca()` function in versions `4.7.900` and above. 
 
-To use Orca to export static images of the graphs you create with the `plotly` R package, you can use the built-in `orca()` funciton in versions `4.7.900` and above.
-
-In order to use the `orca()` function, you need to have the [`processx`](https://github.com/r-lib/processx) R package installed. 
+You need to have the [`processx`](https://github.com/r-lib/processx) R package installed as well. 
 
 The `orca()` function accepts two parameters. The first is the plot to be exported and second is the filename. 
 
-For example, the running the following commands in an R session would export the graph stored in `p` in a file called `surface-plot.svg`:
+For example, running the following commands in an R session would export the graph stored in `p` in a file called `surface-plot.svg`:
 
 ```{r, eval = FALSE}
 if (!require("processx")) install.packages("processx")

--- a/r/2020-01-20-static-image-export.Rmd
+++ b/r/2020-01-20-static-image-export.Rmd
@@ -1,0 +1,51 @@
+---
+description: How to export R graphs as static images.
+display_as: file_settings
+language: r
+layout: base
+name: Exporting Graphs as Static Images
+order: 21
+output:
+  html_document:
+    keep_md: true
+page_type: u-guide
+permalink: r/image-export-orca/
+thumbnail: thumbnail/sizing.png
+---
+
+```{r, echo = FALSE, message=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning=FALSE)
+```
+### New to Plotly?
+
+Plotly's R library is free and open source!<br>
+[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
+You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
+We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
+
+### Version Check
+
+Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
+Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
+```{r}
+library(plotly)
+packageVersion('plotly')
+```
+
+### Export R Graphs As Static Images Using `orca()`
+
+[Orca](https://github.com/plotly/orca) is an open source command line tool for generating static images of graphs created with [Plotly's graphing libraries](https://plot.ly/graphing-libraries). 
+
+To use Orca to export static images of the graphs you create with the `plotly` R package, you can use the built-in `orca()` funciton in versions `4.7.900` and above.
+
+In order to use the `orca()` function, you need to have the [`processx`](https://github.com/r-lib/processx) R package installed. 
+
+The `orca()` function accepts two parameters. The frist is the plot to be exported and second is the filename. 
+
+For example, the running the following commands in an R session would export the graph stored in `p` in a file called `surface-plot.svg`:
+
+```{r, eval = FALSE}
+if (!require("processx")) install.packages("processx")
+p <- plot_ly(z = ~volcano) %>% add_surface()
+orca(p, "surface-plot.svg")
+```

--- a/r/2020-01-20-static-image-export.Rmd
+++ b/r/2020-01-20-static-image-export.Rmd
@@ -16,21 +16,6 @@ thumbnail: thumbnail/sizing.png
 ```{r, echo = FALSE, message=FALSE}
 knitr::opts_chunk$set(message = FALSE, warning=FALSE)
 ```
-### New to Plotly?
-
-Plotly's R library is free and open source!<br>
-[Get started](https://plot.ly/r/getting-started/) by downloading the client and [reading the primer](https://plot.ly/r/getting-started/).<br>
-You can set up Plotly to work in [online](https://plot.ly/r/getting-started/#hosting-graphs-in-your-online-plotly-account) or [offline](https://plot.ly/r/offline/) mode.<br>
-We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/r_cheat_sheet.pdf) (new!) to help you get started!
-
-### Version Check
-
-Version 4 of Plotly's R package is now [available](https://plot.ly/r/getting-started/#installation)!<br>
-Check out [this post](http://moderndata.plot.ly/upgrading-to-plotly-4-0-and-above/) for more information on breaking changes and new features available in this version.
-```{r}
-library(plotly)
-packageVersion('plotly')
-```
 ### Supported File Formats
 
 With the `plotly` R package, you can export graphs you create as static images in the `.png`, `.jpg`/`.jpeg`, `.eps`, `.svg`, and/or `.pdf` formats using[Orca](https://github.com/plotly/orca), an open source command line tool for generating static images of graphs created with [Plotly's graphing libraries](https://plot.ly/graphing-libraries).  

--- a/r/2020-01-20-static-image-export.Rmd
+++ b/r/2020-01-20-static-image-export.Rmd
@@ -53,7 +53,7 @@ The `orca()` function accepts two parameters. The first is the plot to be export
 
 For example, running the following commands in an R session would export the graph stored in `p` in a file called `surface-plot.svg`:
 
-```{r, eval = TRUE}
+```{r, eval = FALSE}
 if (!require("processx")) install.packages("processx")
 p <- plot_ly(z = ~volcano) %>% add_surface()
 orca(p, "surface-plot.svg")

--- a/r/2020-01-20-static-image-export.Rmd
+++ b/r/2020-01-20-static-image-export.Rmd
@@ -40,7 +40,7 @@ To use Orca to export static images of the graphs you create with the `plotly` R
 
 In order to use the `orca()` function, you need to have the [`processx`](https://github.com/r-lib/processx) R package installed. 
 
-The `orca()` function accepts two parameters. The frist is the plot to be exported and second is the filename. 
+The `orca()` function accepts two parameters. The first is the plot to be exported and second is the filename. 
 
 For example, the running the following commands in an R session would export the graph stored in `p` in a file called `surface-plot.svg`:
 


### PR DESCRIPTION
The purpose of this PR is to add a standalone doc about exporting charts as static images to the `plotly fundamentals` section of the R graphing libraries docs. 