### PR TITLE
Fix config reference link & heading

### DIFF
--- a/r/2021-08-27-configuration-options.Rmd
+++ b/r/2021-08-27-configuration-options.Rmd
@@ -354,4 +354,4 @@ The same configuration dictionary that you pass to the `config` parameter can al
 
 #### Reference
 
-See config options at https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L6
+See config options at [https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L6]()

--- a/r/2021-08-27-configuration-options.Rmd
+++ b/r/2021-08-27-configuration-options.Rmd
@@ -352,6 +352,6 @@ config(fig, doubleClickDelay= 1000)%>%layout(plot_bgcolor='#e5ecf6',
 
 The same configuration dictionary that you pass to the `config` parameter can also be passed to the [config property of a `dcc.Graph` component](https://dashr.plotly.com/dash-core-components/graph).
 
-#### Reference
+### Reference
 
 See config options at [https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L6]()


### PR DESCRIPTION
Markdown parses the underscores as _italic_ directive, so the link is unusable:

![image](https://user-images.githubusercontent.com/7782229/149631717-854bddf4-9a2d-491a-97ec-4297393f1809.png)

Correct would be: [https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L6]()

Furthermore, I set the heading level to h3, since this is not a sub-heading of "Configuring Figures in Dash Apps".