### PR TITLE
Fix broken indexing of edgelist coordinates

### DIFF
--- a/r/2015-12-31-network-graph.Rmd
+++ b/r/2015-12-31-network-graph.Rmd
@@ -45,6 +45,9 @@ library(plotly)
 Xn <- L[,1]
 Yn <- L[,2]
 
+names(Xn)<-vs$name
+names(Yn)<-vs$name
+
 network <- plot_ly(x = ~Xn, y = ~Yn, mode = "markers", text = vs$label, hoverinfo = "text")
 ```
 


### PR DESCRIPTION
The vertex coordinates `Xn` and `Yn` are indexed as if they are named vectors, but they are nameless, so `NA` is returned instead of edge endpoints. This PR adds the names.

Currently, the webpage https://plotly.com/r/network-graphs/ produces this plot:

![image](https://user-images.githubusercontent.com/1271481/155914958-f6302f41-17ba-44c1-a957-9a1265759227.png)

This PR produces the (I think) intended plot:

![image](https://user-images.githubusercontent.com/1271481/155915134-d496e49f-3178-4a90-94e9-1c050f0c0293.png)
